### PR TITLE
Add Flyweight artifacts and lean Memento checkpoints for Chapter 14

### DIFF
--- a/metis/conversation_engine.py
+++ b/metis/conversation_engine.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from metis.states.greeting import GreetingState
-from metis.memory.snapshot import ConversationSnapshot
+from metis.memory.pool import ArtifactPool
+from metis.memory.snapshot import ConversationMemento, ConversationSnapshot
 from metis.models.adapters.base import RespondingModel
 from metis.prompts.prompt import Prompt
 
@@ -56,6 +57,11 @@ class ConversationEngine:
             "context": "",
             "tool_output": "",
         }
+
+        # Stable knowledge configured for this conversation. Chapter 14 stores
+        # these values once in the Flyweight pool and puts only references in
+        # subsequent mementos.
+        self.shared_artifacts = {}
 
         # --- Bridge Collaborator (ModelManager) ---
         self.model_manager = model_manager
@@ -564,8 +570,102 @@ class ConversationEngine:
         logger.debug("[ConversationEngine] Snapshot created")
         return snapshot
 
-    def restore_snapshot(self, snapshot):
+    def configure_shared_memory(self, artifacts: Mapping[str, Any]) -> None:
+        """Attach stable prompt, schema, or policy content to the conversation."""
+        self.shared_artifacts = dict(artifacts)
+
+    def create_memento(
+        self,
+        artifact_pool: ArtifactPool,
+        *,
+        tenant_id: str,
+        artifact_versions: Optional[Mapping[str, str]] = None,
+        model_role: Optional[str] = None,
+    ) -> ConversationMemento:
+        """Create a lean checkpoint backed by canonical shared artifacts."""
+        versions = dict(artifact_versions or {})
+        shared_refs = {}
+        for name, content in sorted(self.shared_artifacts.items()):
+            shared_refs[name] = artifact_pool.intern(
+                tenant_id=tenant_id,
+                artifact_type=f"shared:{name}",
+                version=versions.get(name, "v1"),
+                content=content,
+            )
+
+        history_refs = [
+            artifact_pool.intern(
+                tenant_id=tenant_id,
+                artifact_type="conversation-history",
+                version="v1",
+                content=entry,
+            )
+            for entry in self.history
+        ]
+
+        state_class = self.state.__class__ if self.state is not None else GreetingState
+        state_type = f"{state_class.__module__}:{state_class.__qualname__}"
+        if "<locals>" in state_type:
+            raise ValueError(
+                "Lean mementos require an importable conversation state class"
+            )
+
+        resolved_role = model_role or getattr(self.model_manager, "role", None)
+        if not resolved_role:
+            resolved_role = "analysis"
+
+        memento = ConversationMemento.create(
+            state_type=state_type,
+            model_role=str(resolved_role),
+            preferences=self.preferences,
+            history_refs=history_refs,
+            artifact_refs=shared_refs,
+        )
+        logger.debug(
+            "[ConversationEngine] Lean memento created with %d references",
+            len(memento.references),
+        )
+        return memento
+
+    @staticmethod
+    def _instantiate_state(state_type: str):
+        """Recreate a state from the stable module-qualified name in a memento."""
+        import importlib
+
+        module_name, separator, qualified_name = state_type.partition(":")
+        if not separator or not module_name or not qualified_name:
+            raise ValueError(f"Invalid conversation state type: {state_type!r}")
+        target = importlib.import_module(module_name)
+        for part in qualified_name.split("."):
+            target = getattr(target, part)
+        return target()
+
+    def restore_memento(
+        self,
+        memento: ConversationMemento,
+        artifact_pool: ArtifactPool,
+    ) -> None:
+        """Restore session state while retaining live infrastructure objects."""
+        restored = memento.restore_data(artifact_pool)
+        self.state = self._instantiate_state(restored["state_type"])
+        self.history = list(restored["history"])
+        self.preferences = dict(restored["preferences"])
+        self.shared_artifacts = dict(restored["shared_artifacts"])
+        self.model_role = restored["model_role"]
+        self.__dict__.pop("request_handler", None)
+        self._refresh_model_ref()
+        logger.debug("[ConversationEngine] State restored from lean memento")
+
+    def restore_snapshot(self, snapshot, artifact_pool=None):
         """Restore engine state from a previously created snapshot."""
+        if isinstance(snapshot, ConversationMemento):
+            if artifact_pool is None:
+                raise ValueError(
+                    "artifact_pool is required to restore a ConversationMemento"
+                )
+            self.restore_memento(snapshot, artifact_pool)
+            return
+
         state_data = snapshot.get_state()
         # Never restore deprecated/back-compat fields
         if isinstance(state_data, dict):
@@ -586,6 +686,9 @@ class ConversationEngine:
                 "context": "",
                 "tool_output": "",
             }
+
+        if not hasattr(self, "shared_artifacts") or self.shared_artifacts is None:
+            self.shared_artifacts = {}
 
         # Ensure deprecated attribute never exists on the instance
         self.__dict__.pop("request_handler", None)

--- a/metis/examples/chapter14_memory.py
+++ b/metis/examples/chapter14_memory.py
@@ -1,0 +1,107 @@
+"""Runnable Chapter 14 demonstration: Flyweight plus Memento at scale."""
+
+from __future__ import annotations
+
+import os
+import pickle
+from tempfile import TemporaryDirectory
+
+from metis.components.model_manager import ModelManager
+from metis.conversation_engine import ConversationEngine
+from metis.memory import ArtifactPool, MemoryManager
+from metis.models.model_factory import ModelFactory
+
+
+def build_engine() -> ConversationEngine:
+    client = ModelFactory.for_role(
+        "analysis",
+        {"vendor": "mock", "model": "chapter-14", "policies": {}},
+    )
+    engine = ConversationEngine(model_manager=ModelManager(client))
+    engine.configure_shared_memory(
+        {
+            "system_prompt": (
+                "You are Mêtis, a precise orchestration assistant. " * 80
+            ).strip(),
+            "tool_schema": {
+                "tools": [
+                    {
+                        "name": f"knowledge_search_{index}",
+                        "description": "Search approved tenant knowledge safely.",
+                        "arguments": {"query": "string", "limit": "integer"},
+                    }
+                    for index in range(30)
+                ]
+            },
+            "safety_policy": {
+                "version": "2026-07",
+                "rules": [
+                    f"Policy rule {index}: protect tenant data and audit tool access."
+                    for index in range(60)
+                ],
+            },
+        }
+    )
+    return engine
+
+
+def main() -> None:
+    with TemporaryDirectory(prefix="metis-chapter14-") as directory:
+        file_path = os.path.join(directory, "memory.pkl")
+        pool = ArtifactPool()
+        memory = MemoryManager(file_path=file_path, artifact_pool=pool)
+        engine = build_engine()
+        baseline_snapshots = []
+        lean_mementos = []
+
+        for turn in range(1, 4):
+            engine.history.append(
+                f"Turn {turn}: " + "A measured response from Mêtis. " * 25
+            )
+            baseline_snapshots.append(engine.create_snapshot())
+            memento = engine.create_memento(pool, tenant_id="acme")
+            lean_mementos.append(memento)
+            memory.save(memento)
+
+        # Production checkpoint stores commonly serialize records independently.
+        # Summing those records avoids pickle's process-local memo table masking
+        # the duplication that exists across separately persisted snapshots.
+        baseline_bytes = sum(
+            len(pickle.dumps(snapshot, protocol=pickle.HIGHEST_PROTOCOL))
+            for snapshot in baseline_snapshots
+        )
+        optimized_bytes = os.path.getsize(file_path)
+        logical_references = sum(len(memento.references) for memento in lean_mementos)
+        guarded_reference = lean_mementos[0].artifact_refs[0][1]
+
+        expected_history = list(engine.history)
+        engine.history.append("This mutation should disappear after restoration.")
+        restored = memory.restore_into(engine)
+
+        print("Chapter 14 — Flyweight + Memento")
+        print(f"Logical artifact references : {logical_references}")
+        print(f"Unique stored artifacts     : {len(pool)}")
+        print("Reference reuse ratio       : " f"{logical_references / len(pool):.2f}x")
+        print(f"Full-snapshot bytes         : {baseline_bytes:,}")
+        print(f"Lean persistent bytes       : {optimized_bytes:,}")
+        print(
+            "Storage reduction           : "
+            f"{(1 - optimized_bytes / baseline_bytes) * 100:.1f}%"
+        )
+        print(
+            f"Observable state restored   : {restored and engine.history == expected_history}"
+        )
+        print(
+            "Eviction while referenced   : "
+            f"{'blocked' if not pool.evict(guarded_reference) else 'unexpected'}"
+        )
+
+        memory.trim(keep_latest=0)
+        print(
+            "Eviction after release      : "
+            f"{'allowed' if pool.evict(guarded_reference) else 'not found'}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/metis/memory/__init__.py
+++ b/metis/memory/__init__.py
@@ -1,0 +1,22 @@
+"""Conversation memory patterns used by Mêtis."""
+
+from metis.memory.artifact import (
+    ArtifactKey,
+    MemoryReference,
+    MissingArtifactError,
+    SharedMemoryArtifact,
+)
+from metis.memory.manager import MemoryManager
+from metis.memory.pool import ArtifactPool
+from metis.memory.snapshot import ConversationMemento, ConversationSnapshot
+
+__all__ = [
+    "ArtifactKey",
+    "ArtifactPool",
+    "ConversationMemento",
+    "ConversationSnapshot",
+    "MemoryManager",
+    "MemoryReference",
+    "MissingArtifactError",
+    "SharedMemoryArtifact",
+]

--- a/metis/memory/artifact.py
+++ b/metis/memory/artifact.py
@@ -1,0 +1,102 @@
+"""Immutable, content-addressed artifacts used by conversation memory.
+
+The payload is stored as canonical JSON rather than as a mutable Python object.
+Callers receive a freshly decoded value whenever they resolve an artifact, so a
+conversation cannot accidentally change the shared representation in place.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from typing import Any
+
+
+def encode_content(content: Any) -> str:
+    """Return a deterministic JSON representation of an artifact payload."""
+    try:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "Shared memory artifacts must contain JSON-serializable values"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class ArtifactKey:
+    """The tenant-scoped identity of a shared artifact."""
+
+    tenant_id: str
+    artifact_type: str
+    version: str
+    content_hash: str
+
+    @property
+    def identifier(self) -> str:
+        """Return a stable identifier suitable for logs and diagnostics."""
+        return ":".join(
+            (self.tenant_id, self.artifact_type, self.version, self.content_hash)
+        )
+
+
+@dataclass(frozen=True)
+class MemoryReference:
+    """A lightweight reference stored inside a conversation memento."""
+
+    key: ArtifactKey
+
+    @property
+    def identifier(self) -> str:
+        return self.key.identifier
+
+
+@dataclass(frozen=True)
+class SharedMemoryArtifact:
+    """A Flyweight containing immutable, shareable conversation knowledge."""
+
+    key: ArtifactKey
+    encoded_content: str
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        tenant_id: str,
+        artifact_type: str,
+        version: str,
+        content: Any,
+    ) -> "SharedMemoryArtifact":
+        encoded = encode_content(content)
+        digest = sha256(encoded.encode("utf-8")).hexdigest()
+        key = ArtifactKey(
+            tenant_id=str(tenant_id),
+            artifact_type=str(artifact_type),
+            version=str(version),
+            content_hash=digest,
+        )
+        return cls(key=key, encoded_content=encoded)
+
+    def read(self) -> Any:
+        """Decode a fresh value so callers cannot mutate the shared payload."""
+        return json.loads(self.encoded_content)
+
+    @property
+    def size_bytes(self) -> int:
+        return len(self.encoded_content.encode("utf-8"))
+
+
+class MissingArtifactError(KeyError):
+    """Raised when a memento points to an artifact that is no longer present."""
+
+    def __init__(self, reference: MemoryReference):
+        self.reference = reference
+        super().__init__(
+            "Cannot restore conversation memory because artifact "
+            f"'{reference.identifier}' is missing"
+        )

--- a/metis/memory/manager.py
+++ b/metis/memory/manager.py
@@ -1,69 +1,166 @@
-# memory/manager.py
+"""Caretaker for legacy snapshots and reference-based conversation mementos."""
+
+from __future__ import annotations
 
 import os
 import pickle
-from metis.memory.snapshot import ConversationSnapshot
+from typing import Any, Optional
+
+from metis.memory.pool import ArtifactPool
+from metis.memory.snapshot import ConversationMemento, ConversationSnapshot
 
 
 class MemoryManager:
-    """
-    Acts as the Caretaker in the Memento Pattern.
-    Responsible for managing a history of snapshots without needing to understand their contents.
+    """Persist checkpoints while protecting every artifact they reference.
+
+    Legacy ``ConversationSnapshot`` objects remain supported. Chapter 14
+    mementos add lifecycle-aware retain/release behaviour and are stored beside
+    the pool state in a versioned on-disk envelope.
     """
 
-    def __init__(self, file_path="snapshots.pkl"):
+    STORAGE_VERSION = 2
+
+    def __init__(
+        self,
+        file_path: str = "snapshots.pkl",
+        *,
+        artifact_pool: Optional[ArtifactPool] = None,
+        max_snapshots: Optional[int] = None,
+    ):
+        if max_snapshots is not None and max_snapshots < 1:
+            raise ValueError("max_snapshots must be positive or None")
         self._file_path = file_path
-        self._snapshots = self._load_from_disk()
+        self._artifact_pool = (
+            artifact_pool if artifact_pool is not None else ArtifactPool()
+        )
+        self._max_snapshots = max_snapshots
+        self._snapshots: list[Any] = []
+        self._load_from_disk()
 
-    def _load_from_disk(self):
-        """
-        Load the snapshot stack from disk, if available.
-        """
-        if os.path.exists(self._file_path):
-            try:
-                with open(self._file_path, "rb") as f:
-                    snapshots = pickle.load(f)
-                    return snapshots if isinstance(snapshots, list) else []
-            except Exception:
-                return []
-        return []
+    @property
+    def artifact_pool(self) -> ArtifactPool:
+        return self._artifact_pool
 
-    def _save_to_disk(self):
-        """
-        Persist the snapshot stack to disk.
-        """
-        with open(self._file_path, "wb") as f:
-            pickle.dump(self._snapshots, f)
+    def _load_from_disk(self) -> None:
+        """Load both the legacy list and the Chapter 14 storage envelope."""
+        if not os.path.exists(self._file_path):
+            return
+        try:
+            with open(self._file_path, "rb") as stream:
+                stored = pickle.load(stream)
+        except Exception:
+            return
 
-    def save(self, snapshot):
-        """
-        Save a new snapshot to the top of the stack and persist to disk.
+        if isinstance(stored, list):
+            self._snapshots = stored
+            return
 
-        :param snapshot: A ConversationSnapshot instance created by the Originator.
-        """
+        if not isinstance(stored, dict):
+            return
+        snapshots = stored.get("snapshots", [])
+        if isinstance(snapshots, list):
+            self._snapshots = snapshots
+        pool_state = stored.get("artifact_pool")
+        if isinstance(pool_state, dict):
+            self._artifact_pool.import_state(pool_state)
+
+    def _save_to_disk(self) -> None:
+        """Atomically persist checkpoints and the artifacts needed to restore them."""
+        directory = os.path.dirname(os.path.abspath(self._file_path))
+        os.makedirs(directory, exist_ok=True)
+        temporary_path = f"{self._file_path}.tmp"
+        payload = {
+            "storage_version": self.STORAGE_VERSION,
+            "snapshots": self._snapshots,
+            "artifact_pool": dict(self._artifact_pool.export_state()),
+        }
+        with open(temporary_path, "wb") as stream:
+            pickle.dump(payload, stream)
+        os.replace(temporary_path, self._file_path)
+
+    @staticmethod
+    def _memento_references(snapshot: Any):
+        if isinstance(snapshot, ConversationMemento):
+            return snapshot.references
+        return ()
+
+    def save(self, snapshot: Any) -> None:
+        """Retain a checkpoint and pin all artifacts on which it depends."""
         if snapshot is None:
             return
+        references = self._memento_references(snapshot)
+        if references:
+            self._artifact_pool.retain(references)
         self._snapshots.append(snapshot)
+        self._trim_to_limit()
+        self._artifact_pool.evict_unreferenced()
         self._save_to_disk()
 
-    def restore_last(self):
-        """
-        Restore the most recent snapshot from the stack.
+    def _trim_to_limit(self) -> None:
+        if self._max_snapshots is None:
+            return
+        while len(self._snapshots) > self._max_snapshots:
+            removed = self._snapshots.pop(0)
+            self._artifact_pool.release(self._memento_references(removed))
 
-        :return: The latest snapshot if available; otherwise an empty ConversationSnapshot.
+    def trim(self, keep_latest: int) -> int:
+        """Discard older checkpoints and release their artifact dependencies."""
+        if keep_latest < 0:
+            raise ValueError("keep_latest must be zero or greater")
+        remove_count = max(0, len(self._snapshots) - keep_latest)
+        removed = self._snapshots[:remove_count]
+        self._snapshots = self._snapshots[remove_count:]
+        for snapshot in removed:
+            self._artifact_pool.release(self._memento_references(snapshot))
+        self._artifact_pool.evict_unreferenced()
+        self._save_to_disk()
+        return len(removed)
+
+    def restore_into(self, originator: Any) -> bool:
+        """Restore and consume the latest checkpoint as one safe lifecycle step.
+
+        The checkpoint is removed and its references are released only after the
+        originator has successfully resolved and restored it.
+        """
+        if not self._snapshots:
+            return False
+        snapshot = self._snapshots[-1]
+        if isinstance(snapshot, ConversationMemento):
+            originator.restore_snapshot(snapshot, artifact_pool=self._artifact_pool)
+        else:
+            originator.restore_snapshot(snapshot)
+        self._snapshots.pop()
+        self._artifact_pool.release(self._memento_references(snapshot))
+        self._artifact_pool.evict_unreferenced()
+        self._save_to_disk()
+        return True
+
+    def restore_last(self):
+        """Pop the latest checkpoint, preserving the earlier public API.
+
+        A returned lean memento remains pinned until ``release`` is called. New
+        code should prefer ``restore_into`` so resolving and releasing happen as
+        one operation.
         """
         if self._snapshots:
             snapshot = self._snapshots.pop()
             self._save_to_disk()
             return snapshot
-
-        # IMPORTANT: Return an empty snapshot instead of None
         return ConversationSnapshot({})
 
-    def clear(self):
-        """
-        Clear all saved snapshots.
-        Useful when resetting the conversation or after critical errors.
-        """
-        self._snapshots.clear()
+    def release(self, snapshot: Any) -> None:
+        """Release a memento obtained with the compatibility ``restore_last`` API."""
+        self._artifact_pool.release(self._memento_references(snapshot))
+        self._artifact_pool.evict_unreferenced()
         self._save_to_disk()
+
+    def clear(self) -> None:
+        """Clear saved checkpoints and release their dependencies."""
+        for snapshot in self._snapshots:
+            self._artifact_pool.release(self._memento_references(snapshot))
+        self._snapshots.clear()
+        self._artifact_pool.evict_unreferenced()
+        self._save_to_disk()
+
+    def __len__(self) -> int:
+        return len(self._snapshots)

--- a/metis/memory/pool.py
+++ b/metis/memory/pool.py
@@ -1,0 +1,153 @@
+"""Flyweight factory and lifecycle manager for shared memory artifacts."""
+
+from __future__ import annotations
+
+from collections import Counter, OrderedDict
+from typing import Any, Iterable, Mapping, Optional
+
+from metis.memory.artifact import (
+    ArtifactKey,
+    MemoryReference,
+    MissingArtifactError,
+    SharedMemoryArtifact,
+)
+
+
+class ArtifactPool:
+    """Intern, resolve, retain, and safely evict shared artifacts.
+
+    ``intern`` is the Flyweight factory operation: equivalent content with the
+    same tenant, type, and version resolves to the same stored artifact. Pin
+    counts express live memento dependencies and prevent unsafe eviction.
+    """
+
+    STATE_VERSION = 1
+
+    def __init__(self, max_entries: Optional[int] = None):
+        if max_entries is not None and max_entries < 1:
+            raise ValueError("max_entries must be positive or None")
+        self.max_entries = max_entries
+        self._artifacts: "OrderedDict[ArtifactKey, SharedMemoryArtifact]" = (
+            OrderedDict()
+        )
+        self._pins: "Counter[ArtifactKey]" = Counter()
+
+    def intern(
+        self,
+        *,
+        tenant_id: str,
+        artifact_type: str,
+        version: str,
+        content: Any,
+    ) -> MemoryReference:
+        """Return the canonical reference for a tenant-scoped value."""
+        artifact = SharedMemoryArtifact.create(
+            tenant_id=tenant_id,
+            artifact_type=artifact_type,
+            version=version,
+            content=content,
+        )
+        existing = self._artifacts.get(artifact.key)
+        if existing is None:
+            self._artifacts[artifact.key] = artifact
+        else:
+            self._artifacts.move_to_end(artifact.key)
+        return MemoryReference(artifact.key)
+
+    def get(self, reference: MemoryReference) -> SharedMemoryArtifact:
+        """Return the canonical Flyweight or raise a diagnostic error."""
+        try:
+            artifact = self._artifacts[reference.key]
+        except KeyError as exc:
+            raise MissingArtifactError(reference) from exc
+        self._artifacts.move_to_end(reference.key)
+        return artifact
+
+    def resolve(self, reference: MemoryReference) -> Any:
+        """Resolve a reference to a fresh, caller-owned value."""
+        return self.get(reference).read()
+
+    def retain(self, references: Iterable[MemoryReference]) -> None:
+        """Pin artifacts while one or more retained mementos reference them."""
+        for reference in references:
+            self.get(reference)
+            self._pins[reference.key] += 1
+
+    def release(self, references: Iterable[MemoryReference]) -> None:
+        """Release memento pins without deleting the underlying artifacts."""
+        for reference in references:
+            count = self._pins.get(reference.key, 0)
+            if count <= 1:
+                self._pins.pop(reference.key, None)
+            else:
+                self._pins[reference.key] = count - 1
+
+    def pin_count(self, reference: MemoryReference) -> int:
+        return self._pins.get(reference.key, 0)
+
+    def evict(self, reference: MemoryReference, *, force: bool = False) -> bool:
+        """Evict an artifact unless a live memento still depends on it."""
+        if reference.key not in self._artifacts:
+            return False
+        if not force and self._pins.get(reference.key, 0) > 0:
+            return False
+        del self._artifacts[reference.key]
+        self._pins.pop(reference.key, None)
+        return True
+
+    def evict_unreferenced(self, target_size: Optional[int] = None) -> int:
+        """Evict least-recently-used, unpinned entries down to ``target_size``."""
+        target = self.max_entries if target_size is None else target_size
+        if target is None:
+            return 0
+        if target < 0:
+            raise ValueError("target_size must be zero or greater")
+
+        removed = 0
+        for key in list(self._artifacts.keys()):
+            if len(self._artifacts) <= target:
+                break
+            if self._pins.get(key, 0) > 0:
+                continue
+            del self._artifacts[key]
+            removed += 1
+        return removed
+
+    def export_state(self) -> Mapping[str, Any]:
+        """Return a pickle-safe representation for the caretaker."""
+        return {
+            "version": self.STATE_VERSION,
+            "max_entries": self.max_entries,
+            "artifacts": list(self._artifacts.values()),
+            "pins": dict(self._pins),
+        }
+
+    def import_state(self, state: Mapping[str, Any]) -> None:
+        """Merge a previously exported pool state into this pool."""
+        if not isinstance(state, Mapping):
+            return
+        stored_limit = state.get("max_entries")
+        if self.max_entries is None and (
+            stored_limit is None or isinstance(stored_limit, int)
+        ):
+            self.max_entries = stored_limit
+        for artifact in state.get("artifacts", []):
+            if isinstance(artifact, SharedMemoryArtifact):
+                self._artifacts[artifact.key] = artifact
+        for key, count in state.get("pins", {}).items():
+            if isinstance(key, ArtifactKey) and isinstance(count, int) and count > 0:
+                self._pins[key] = count
+
+    def stats(self) -> Mapping[str, int]:
+        """Expose observable measures without revealing artifact contents."""
+        return {
+            "artifacts": len(self._artifacts),
+            "pinned_artifacts": sum(1 for count in self._pins.values() if count),
+            "references": sum(self._pins.values()),
+            "stored_bytes": sum(
+                artifact.size_bytes for artifact in self._artifacts.values()
+            ),
+        }
+
+    def __len__(self) -> int:
+        return len(self._artifacts)

--- a/metis/memory/snapshot.py
+++ b/metis/memory/snapshot.py
@@ -1,6 +1,15 @@
-# memory/snapshot.py
+"""Full snapshots and lean, reference-based conversation mementos."""
+
+from __future__ import annotations
 
 import copy
+from dataclasses import dataclass
+import json
+from typing import Any, Iterable, Mapping, Tuple
+
+from metis.memory.artifact import MemoryReference, encode_content
+from metis.memory.pool import ArtifactPool
+
 
 class ConversationSnapshot:
     """
@@ -24,3 +33,63 @@ class ConversationSnapshot:
         :return: A deep copy of the saved internal state dictionary.
         """
         return copy.deepcopy(self._state_data)
+
+
+@dataclass(frozen=True)
+class ConversationMemento:
+    """A lean checkpoint containing references plus session-specific state.
+
+    Unlike ``ConversationSnapshot``, this object does not copy model clients,
+    prompt text, tool schemas, safety policies, or history payloads. Those
+    values live in the artifact pool and are addressed by immutable references.
+    """
+
+    schema_version: int
+    state_type: str
+    model_role: str
+    preferences_json: str
+    history_refs: Tuple[MemoryReference, ...]
+    artifact_refs: Tuple[Tuple[str, MemoryReference], ...]
+
+    CURRENT_SCHEMA_VERSION = 2
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        state_type: str,
+        model_role: str,
+        preferences: Mapping[str, Any],
+        history_refs: Iterable[MemoryReference],
+        artifact_refs: Mapping[str, MemoryReference],
+    ) -> "ConversationMemento":
+        return cls(
+            schema_version=cls.CURRENT_SCHEMA_VERSION,
+            state_type=state_type,
+            model_role=model_role,
+            preferences_json=encode_content(dict(preferences)),
+            history_refs=tuple(history_refs),
+            artifact_refs=tuple(sorted(artifact_refs.items())),
+        )
+
+    @property
+    def references(self) -> Tuple[MemoryReference, ...]:
+        """Return every artifact dependency held by this checkpoint."""
+        return self.history_refs + tuple(ref for _, ref in self.artifact_refs)
+
+    def restore_data(self, pool: ArtifactPool) -> Mapping[str, Any]:
+        """Resolve a checkpoint into state owned by the restoring conversation."""
+        if self.schema_version != self.CURRENT_SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported conversation memento schema version: "
+                f"{self.schema_version}"
+            )
+        return {
+            "state_type": self.state_type,
+            "model_role": self.model_role,
+            "preferences": json.loads(self.preferences_json),
+            "history": [pool.resolve(ref) for ref in self.history_refs],
+            "shared_artifacts": {
+                name: pool.resolve(ref) for name, ref in self.artifact_refs
+            },
+        }

--- a/tests/memory/test_artifact_pool.py
+++ b/tests/memory/test_artifact_pool.py
@@ -1,0 +1,84 @@
+import pytest
+
+from metis.memory import ArtifactPool, MissingArtifactError
+
+
+def test_pool_reuses_canonical_artifact_within_tenant_and_version():
+    pool = ArtifactPool()
+
+    first = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="system-prompt",
+        version="v1",
+        content={"role": "helpful"},
+    )
+    second = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="system-prompt",
+        version="v1",
+        content={"role": "helpful"},
+    )
+
+    assert first == second
+    assert pool.get(first) is pool.get(second)
+    assert len(pool) == 1
+
+
+def test_pool_keys_prevent_cross_tenant_and_cross_version_reuse():
+    pool = ArtifactPool()
+    common = {"role": "helpful"}
+
+    tenant_a_v1 = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="system-prompt",
+        version="v1",
+        content=common,
+    )
+    tenant_b_v1 = pool.intern(
+        tenant_id="tenant-b",
+        artifact_type="system-prompt",
+        version="v1",
+        content=common,
+    )
+    tenant_a_v2 = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="system-prompt",
+        version="v2",
+        content=common,
+    )
+
+    assert len({tenant_a_v1, tenant_b_v1, tenant_a_v2}) == 3
+    assert len(pool) == 3
+
+
+def test_resolved_values_cannot_mutate_the_shared_artifact():
+    pool = ArtifactPool()
+    reference = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="tool-schema",
+        version="v1",
+        content={"tools": ["search"]},
+    )
+
+    resolved = pool.resolve(reference)
+    resolved["tools"].append("delete")
+
+    assert pool.resolve(reference) == {"tools": ["search"]}
+
+
+def test_pinned_artifact_resists_eviction_until_released():
+    pool = ArtifactPool()
+    reference = pool.intern(
+        tenant_id="tenant-a",
+        artifact_type="safety-policy",
+        version="v1",
+        content={"blocked": ["secret"]},
+    )
+
+    pool.retain([reference])
+    assert pool.evict(reference) is False
+
+    pool.release([reference])
+    assert pool.evict(reference) is True
+    with pytest.raises(MissingArtifactError, match="Cannot restore"):
+        pool.resolve(reference)

--- a/tests/memory/test_lean_memento.py
+++ b/tests/memory/test_lean_memento.py
@@ -1,0 +1,121 @@
+import pytest
+
+from metis.components.model_manager import ModelManager
+from metis.conversation_engine import ConversationEngine
+from metis.memory import (
+    ArtifactPool,
+    ConversationMemento,
+    MemoryManager,
+    MissingArtifactError,
+)
+from metis.models.model_factory import ModelFactory
+from metis.states.clarifying import ClarifyingState
+
+
+def _engine(model="A") -> ConversationEngine:
+    client = ModelFactory.for_role(
+        "analysis", {"vendor": "mock", "model": model, "policies": {}}
+    )
+    return ConversationEngine(model_manager=ModelManager(client))
+
+
+def _configure(engine: ConversationEngine) -> None:
+    engine.configure_shared_memory(
+        {
+            "system_prompt": "You are Mêtis, a careful orchestration assistant.",
+            "tool_schema": {"tools": [{"name": "search", "args": ["query"]}]},
+            "safety_policy": {"version": 3, "rules": ["protect tenant data"]},
+        }
+    )
+
+
+def test_lean_mementos_share_artifacts_and_restore_session_state(tmp_path):
+    pool = ArtifactPool()
+    memory = MemoryManager(file_path=str(tmp_path / "memory.pkl"), artifact_pool=pool)
+    engine = _engine("A")
+    _configure(engine)
+    engine.state = ClarifyingState()
+    engine.preferences["tone"] = "concise"
+    engine.history = ["first response", "second response"]
+
+    first = engine.create_memento(pool, tenant_id="tenant-a")
+    second = engine.create_memento(pool, tenant_id="tenant-a")
+    assert isinstance(first, ConversationMemento)
+    assert first.artifact_refs == second.artifact_refs
+    assert first.history_refs == second.history_refs
+    assert len(pool) == 5
+
+    memory.save(first)
+    original_manager = engine.model_manager
+    engine.state = None
+    engine.preferences["tone"] = "playful"
+    engine.history.append("not retained")
+    engine.shared_artifacts = {}
+
+    assert memory.restore_into(engine) is True
+    assert isinstance(engine.state, ClarifyingState)
+    assert engine.preferences["tone"] == "concise"
+    assert engine.history == ["first response", "second response"]
+    assert engine.shared_artifacts["tool_schema"]["tools"][0]["name"] == "search"
+    assert engine.model_manager is original_manager
+
+
+def test_reference_aware_trimming_releases_only_dead_artifacts(tmp_path):
+    pool = ArtifactPool(max_entries=4)
+    memory = MemoryManager(
+        file_path=str(tmp_path / "memory.pkl"),
+        artifact_pool=pool,
+        max_snapshots=1,
+    )
+    engine = _engine()
+    _configure(engine)
+
+    engine.history = ["old response"]
+    old = engine.create_memento(pool, tenant_id="tenant-a")
+    old_history_reference = old.history_refs[0]
+    memory.save(old)
+
+    engine.history = ["new response"]
+    new = engine.create_memento(pool, tenant_id="tenant-a")
+    memory.save(new)
+
+    assert len(memory) == 1
+    assert pool.pin_count(old_history_reference) == 0
+    with pytest.raises(MissingArtifactError):
+        pool.resolve(old_history_reference)
+    for reference in new.references:
+        assert pool.pin_count(reference) == 1
+        pool.resolve(reference)
+
+
+def test_missing_artifact_failure_keeps_checkpoint_for_recovery(tmp_path):
+    pool = ArtifactPool()
+    memory = MemoryManager(file_path=str(tmp_path / "memory.pkl"), artifact_pool=pool)
+    engine = _engine()
+    _configure(engine)
+    engine.history = ["recover me"]
+    memento = engine.create_memento(pool, tenant_id="tenant-a")
+    memory.save(memento)
+
+    pool.evict(memento.history_refs[0], force=True)
+
+    with pytest.raises(MissingArtifactError):
+        memory.restore_into(engine)
+    assert len(memory) == 1
+
+
+def test_pool_and_memento_survive_manager_restart(tmp_path):
+    file_path = str(tmp_path / "memory.pkl")
+    memory = MemoryManager(file_path=file_path)
+    engine = _engine()
+    _configure(engine)
+    engine.history = ["persisted response"]
+    memory.save(engine.create_memento(memory.artifact_pool, tenant_id="tenant-a"))
+
+    restarted = MemoryManager(file_path=file_path)
+    restored_engine = _engine("B")
+
+    assert restarted.restore_into(restored_engine) is True
+    assert restored_engine.history == ["persisted response"]
+    assert restored_engine.shared_artifacts["system_prompt"].startswith("You are Mêtis")
+    assert "[mock:b]" in restored_engine.generate_with_model("still live").lower()


### PR DESCRIPTION
## Summary

This pull request implements the Chapter 14 memory architecture by combining the Flyweight and Memento design patterns.

Mêtis can now store stable conversation knowledge—such as system prompts, tool schemas, safety policies, and history entries—as immutable, content-addressed artifacts. Lean conversation mementos retain references to those artifacts alongside session-specific state, avoiding repeated copies of the same content.

The existing `ConversationSnapshot` API remains available for backward compatibility.

## Changes

- Added immutable, tenant-scoped `SharedMemoryArtifact` objects.
- Added content-addressed artifact identities based on tenant, artifact type, version, and content hash.
- Added an `ArtifactPool` that canonicalises and reuses equivalent artifacts.
- Added reference counting to protect artifacts required by retained checkpoints.
- Added reference-aware eviction that prevents removal of live dependencies.
- Added a versioned `ConversationMemento` containing:
  - Conversation state type
  - Model role
  - Session preferences
  - History references
  - Shared artifact references
- Extended `ConversationEngine` with:
  - `configure_shared_memory()`
  - `create_memento()`
  - `restore_memento()`
  - Lean-memento support in `restore_snapshot()`
- Extended `MemoryManager` with:
  - Versioned checkpoint and artifact-pool persistence
  - Bounded checkpoint retention
  - Reference-aware trimming
  - Safe `restore_into()` lifecycle
  - Explicit release support for the legacy `restore_last()` workflow
- Added a deterministic `MissingArtifactError` for unresolved checkpoint dependencies.
- Added a runnable Chapter 14 demonstration.
- Added unit and integration coverage for artifact reuse, isolation, immutability, persistence, restoration and eviction.

## Backward compatibility

The existing `ConversationSnapshot`, `create_snapshot()` and `restore_last()` behaviour remains supported. Earlier chapter examples and tests can continue using full snapshots while Chapter 14 code adopts the lean memento path.

Lean mementos deliberately exclude live infrastructure objects such as model clients and tool executors. Restoration recovers conversation state while retaining the engine’s currently configured runtime collaborators.

## Verification

The complete test suite passes:

```text
245 passed
```

The Chapter 14 demonstration produced:

```text
Logical artifact references : 15
Unique stored artifacts     : 6
Reference reuse ratio       : 2.50x
Full-snapshot bytes         : 35,519
Lean persistent bytes       : 17,153
Storage reduction           : 51.7%
Observable state restored   : True
Eviction while referenced   : blocked
Eviction after release      : allowed
```

## Files added

- `metis/memory/artifact.py`
- `metis/memory/pool.py`
- `examples/chapter14_memory.py`
- `tests/memory/test_artifact_pool.py`
- `tests/memory/test_lean_memento.py`

## Files updated

- `metis/conversation_engine.py`
- `metis/memory/__init__.py`
- `metis/memory/manager.py`
- `metis/memory/snapshot.py`

No files were deleted.