### PR TITLE
 Implement Chapter 15 Null Object pattern for event publishing

### DIFF
--- a/metis/components/model_manager.py
+++ b/metis/components/model_manager.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 """
 ModelManager acts as the Bridge implementor, routing text generation requests to a unified model interface.
 
@@ -10,19 +11,26 @@ Adapters and proxies may return richer payloads internally, but ModelManager
 is the *single normalization point* that always returns plain text.
 """
 
+import logging
 from typing import Any
 from uuid import uuid4
 
+from metis.events import Event, EventPublisher, NullEventPublisher
 from metis.models.adapters.base import RespondingModel
-from metis.events import Event
-import logging
 
 logger = logging.getLogger(__name__)
 
+
 class ModelManager:
-    def __init__(self, model_client: RespondingModel, event_bus=None):
+    def __init__(
+        self,
+        model_client: RespondingModel,
+        event_bus: EventPublisher | None = None,
+    ):
         self.model_client: RespondingModel = model_client
-        self.event_bus = event_bus
+        self.event_bus: EventPublisher = (
+            event_bus if event_bus is not None else NullEventPublisher()
+        )
         logger.debug("[ModelManager] model_client=%s", type(self.model_client).__name__)
 
     def generate(self, prompt: str, **kwargs: Any) -> str:
@@ -38,22 +46,23 @@ class ModelManager:
             "model_client": type(self.model_client).__name__,
         }
 
-        if self.event_bus is not None:
-            self.event_bus.publish(
-                Event.create(
-                    event_type="model.requested",
-                    source="ModelManager",
-                    correlation_id=correlation_id,
-                    payload={
-                        "prompt_length": len(prompt or ""),
-                    },
-                    metadata=metadata,
-                )
+        self.event_bus.publish(
+            Event.create(
+                event_type="model.requested",
+                source="ModelManager",
+                correlation_id=correlation_id,
+                payload={
+                    "prompt_length": len(prompt or ""),
+                },
+                metadata=metadata,
             )
+        )
 
         try:
             # Preferred path: adapters / proxies exposing `generate()`
-            if hasattr(self.model_client, "generate") and callable(getattr(self.model_client, "generate")):
+            if hasattr(self.model_client, "generate") and callable(
+                getattr(self.model_client, "generate")
+            ):
                 out = getattr(self.model_client, "generate")(prompt, **kwargs)
 
                 if isinstance(out, dict):
@@ -66,38 +75,36 @@ class ModelManager:
                 # Fallback: minimal responding interface
                 result = self.model_client.respond(prompt, **kwargs)
 
-            if self.event_bus is not None:
-                self.event_bus.publish(
-                    Event.create(
-                        event_type="model.responded",
-                        source="ModelManager",
-                        correlation_id=correlation_id,
-                        payload={
-                            "prompt_length": len(prompt or ""),
-                            "response_length": len(result or ""),
-                        },
-                        metadata=metadata,
-                    )
+            self.event_bus.publish(
+                Event.create(
+                    event_type="model.responded",
+                    source="ModelManager",
+                    correlation_id=correlation_id,
+                    payload={
+                        "prompt_length": len(prompt or ""),
+                        "response_length": len(result or ""),
+                    },
+                    metadata=metadata,
                 )
+            )
 
             return result
 
         except Exception as exc:
-            if self.event_bus is not None:
-                self.event_bus.publish(
-                    Event.create(
-                        event_type="model.failed",
-                        source="ModelManager",
-                        correlation_id=correlation_id,
-                        payload={
-                            "prompt_length": len(prompt or ""),
-                            "error_type": exc.__class__.__name__,
-                            "error_message": str(exc),
-                        },
-                        metadata=metadata,
-                        severity="ERROR",
-                    )
+            self.event_bus.publish(
+                Event.create(
+                    event_type="model.failed",
+                    source="ModelManager",
+                    correlation_id=correlation_id,
+                    payload={
+                        "prompt_length": len(prompt or ""),
+                        "error_type": exc.__class__.__name__,
+                        "error_message": str(exc),
+                    },
+                    metadata=metadata,
+                    severity="ERROR",
                 )
+            )
             raise
 
     def respond(self, prompt: str, **kwargs: Any) -> str:

--- a/metis/events/__init__.py
+++ b/metis/events/__init__.py
@@ -7,16 +7,18 @@ Observer Pattern in the system:
 - Event: the structured event envelope used across the application
 - Observer: the observer contract
 - EventBus: the in-process event dispatcher
+- EventPublisher: the narrow publishing contract
+- NullEventPublisher: the neutral publisher used when dispatch is optional
 
 Keeping these exports in __init__.py makes imports elsewhere in the
 codebase simpler and more readable, for example:
 
-    from metis.events import Event, EventBus, Observer
+    from metis.events import Event, EventBus, EventPublisher, Observer
 """
-
 
 from .bus import EventBus, Observer
 from .event import Event
+from .publisher import EventPublisher, NullEventPublisher
 from .observers import (
     AnalyticsObserver,
     LoggingObserver,
@@ -28,6 +30,8 @@ __all__ = [
     "Event",
     "Observer",
     "EventBus",
+    "EventPublisher",
+    "NullEventPublisher",
     "LoggingObserver",
     "MetricsObserver",
     "AnalyticsObserver",

--- a/metis/events/publisher.py
+++ b/metis/events/publisher.py
@@ -1,0 +1,26 @@
+"""Publishing contract and neutral implementation for optional events."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from .event import Event
+
+
+@runtime_checkable
+class EventPublisher(Protocol):
+    """Minimal event capability required by publishing clients."""
+
+    def publish(self, event: Event) -> None:
+        """Publish an event according to the implementation's semantics."""
+        ...
+
+
+class NullEventPublisher:
+    """Accept events without dispatching, storing, or acknowledging them."""
+
+    __slots__ = ()
+
+    def publish(self, event: Event) -> None:
+        """Discard an event and preserve the caller's control flow."""
+        return None

--- a/metis/examples/chapter15_null_object.py
+++ b/metis/examples/chapter15_null_object.py
@@ -1,0 +1,61 @@
+"""Compare real, null, and omitted event publishers for Chapter 15."""
+
+from __future__ import annotations
+
+import argparse
+
+from metis.components.model_manager import ModelManager
+from metis.events import Event, EventBus, NullEventPublisher
+from metis.models.adapters.mock_adapter import MockAdapter
+
+
+class EventCollector:
+    def __init__(self) -> None:
+        self.events: list[Event] = []
+
+    def notify(self, event: Event) -> None:
+        self.events.append(event)
+
+
+def build_manager(mode: str) -> tuple[ModelManager, EventCollector]:
+    client = MockAdapter("chapter-15")
+    collector = EventCollector()
+
+    if mode == "real":
+        publisher = EventBus()
+        publisher.subscribe_all(collector)
+        return ModelManager(client, event_bus=publisher), collector
+
+    if mode == "null":
+        return (
+            ModelManager(client, event_bus=NullEventPublisher()),
+            collector,
+        )
+
+    return ModelManager(client), collector
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare Chapter 15 event-publisher configurations."
+    )
+    parser.add_argument(
+        "--publisher",
+        choices=("real", "null", "omitted"),
+        default="omitted",
+    )
+    parser.add_argument("--prompt", default="Continue")
+    args = parser.parse_args()
+
+    manager, collector = build_manager(args.publisher)
+    response = manager.generate(args.prompt, correlation_id="chapter-15-demo")
+
+    print(f"Configuration: {args.publisher}")
+    print(f"Publisher: {type(manager.event_bus).__name__}")
+    print(f"Events captured: {len(collector.events)}")
+    print(f"Response: {response}")
+    print("Core request: complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/metis/scheduling/worker.py
+++ b/metis/scheduling/worker.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 from uuid import uuid4
 
-from metis.events import Event
+from metis.events import Event, EventPublisher, NullEventPublisher
 
 from .clock import Clock
 from .retry import RetryPolicy, FixedDelayRetryPolicy
@@ -29,13 +29,15 @@ class Worker:
         clock: Clock | None = None,
         retry_policy: RetryPolicy | None = None,
         executor_registry: Any = None,
-        event_bus: Any = None,
+        event_bus: EventPublisher | None = None,
     ):
         self.scheduler = scheduler
         self.clock = clock or Clock()
         self.retry_policy = retry_policy or FixedDelayRetryPolicy()
         self.executor_registry = executor_registry
-        self.event_bus = event_bus
+        self.event_bus: EventPublisher = (
+            event_bus if event_bus is not None else NullEventPublisher()
+        )
 
     def _publish_task_event(
         self,
@@ -43,18 +45,15 @@ class Worker:
         event_type: str,
         *,
         severity: str = "INFO",
-        extra_payload: dict | None = None,
+        extra_payload: dict[str, Any] | None = None,
     ) -> None:
         """
-        Publish a task lifecycle event when an EventBus is configured.
+        Publish a task lifecycle event through the configured publisher.
 
         Worker owns task execution state transitions, so it is the correct
         publisher for task.started / task.completed / task.failed / task.retried
         / task.abandoned events.
         """
-        if self.event_bus is None:
-            return
-
         correlation_id = None
         if isinstance(task.payload, dict):
             correlation_id = task.payload.get("correlation_id")
@@ -64,7 +63,9 @@ class Worker:
         payload = {
             "task_id": task.id,
             "task_type": task.task_type,
-            "status": task.status.value if hasattr(task.status, "value") else str(task.status),
+            "status": (
+                task.status.value if hasattr(task.status, "value") else str(task.status)
+            ),
             "retries": task.retries,
             "max_retries": task.max_retries,
         }
@@ -100,7 +101,9 @@ class Worker:
 
         return processed
 
-    def _execute_task(self, task: BackgroundCommand, context: Any = None) -> BackgroundCommand:
+    def _execute_task(
+        self, task: BackgroundCommand, context: Any = None
+    ) -> BackgroundCommand:
         """
         Execute one task and update its lifecycle state.
 
@@ -148,15 +151,19 @@ class Worker:
             # Retry if still within the allowed attempt budget.
             if task.retries <= task.max_retries:
                 task.status = TaskStatus.SCHEDULED
-                task.scheduled_for = self.clock.now() + self.retry_policy.next_delay(task.retries)
+                task.scheduled_for = self.clock.now() + self.retry_policy.next_delay(
+                    task.retries
+                )
                 self._publish_task_event(
                     task,
                     "task.retried",
                     severity="WARNING",
                     extra_payload={
-                        "next_scheduled_for": task.scheduled_for.isoformat()
-                        if hasattr(task.scheduled_for, "isoformat")
-                        else str(task.scheduled_for),
+                        "next_scheduled_for": (
+                            task.scheduled_for.isoformat()
+                            if hasattr(task.scheduled_for, "isoformat")
+                            else str(task.scheduled_for)
+                        ),
                     },
                 )
             else:

--- a/tests/components/test_model_manager_events.py
+++ b/tests/components/test_model_manager_events.py
@@ -1,0 +1,76 @@
+import pytest
+
+from metis.components.model_manager import ModelManager
+from metis.events import EventBus, NullEventPublisher
+from metis.models.adapters.mock_adapter import MockAdapter
+
+
+class SpyObserver:
+    def __init__(self):
+        self.events = []
+
+    def notify(self, event):
+        self.events.append(event)
+
+
+class FailingModel:
+    def respond(self, prompt, **kwargs):
+        raise RuntimeError("storm ahead")
+
+
+class FalseyPublisher:
+    def __init__(self):
+        self.events = []
+
+    def __bool__(self):
+        return False
+
+    def publish(self, event):
+        self.events.append(event)
+
+
+def test_omitted_publisher_selects_null_publisher():
+    manager = ModelManager(MockAdapter("chapter-15"))
+
+    assert isinstance(manager.event_bus, NullEventPublisher)
+
+
+def test_explicit_falsey_publisher_is_not_replaced():
+    publisher = FalseyPublisher()
+    manager = ModelManager(MockAdapter("chapter-15"), event_bus=publisher)
+
+    manager.generate("Continue")
+
+    assert manager.event_bus is publisher
+    assert len(publisher.events) == 2
+
+
+def test_publisher_choice_does_not_change_model_output():
+    client = MockAdapter("chapter-15")
+
+    observed = ModelManager(client, EventBus()).generate("Continue")
+    silent = ModelManager(client, NullEventPublisher()).generate("Continue")
+
+    assert observed == silent
+
+
+def test_real_bus_receives_model_lifecycle_events():
+    bus = EventBus()
+    observer = SpyObserver()
+    bus.subscribe_all(observer)
+    manager = ModelManager(MockAdapter("chapter-15"), event_bus=bus)
+
+    manager.generate("Continue", correlation_id="corr-model-15")
+
+    assert [event.event_type for event in observer.events] == [
+        "model.requested",
+        "model.responded",
+    ]
+    assert {event.correlation_id for event in observer.events} == {"corr-model-15"}
+
+
+def test_null_publisher_does_not_suppress_model_failure():
+    manager = ModelManager(FailingModel(), event_bus=NullEventPublisher())
+
+    with pytest.raises(RuntimeError, match="storm ahead"):
+        manager.generate("Continue")

--- a/tests/events/test_null_event_publisher.py
+++ b/tests/events/test_null_event_publisher.py
@@ -1,0 +1,27 @@
+import pytest
+
+from metis.events import Event, EventBus, EventPublisher, NullEventPublisher
+
+
+def make_event() -> Event:
+    return Event.create(
+        event_type="model.requested",
+        source="ModelManager",
+        correlation_id="corr-chapter-15",
+    )
+
+
+@pytest.mark.parametrize("publisher_type", [EventBus, NullEventPublisher])
+def test_publishers_share_the_publishing_contract(publisher_type):
+    publisher = publisher_type()
+
+    assert isinstance(publisher, EventPublisher)
+    assert publisher.publish(make_event()) is None
+
+
+def test_null_publisher_retains_no_instance_state():
+    publisher = NullEventPublisher()
+
+    publisher.publish(make_event())
+
+    assert not hasattr(publisher, "__dict__")

--- a/tests/scheduling/test_scheduler_worker.py
+++ b/tests/scheduling/test_scheduler_worker.py
@@ -1,9 +1,23 @@
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timedelta, timezone
 
+from metis.events import NullEventPublisher
 from metis.scheduling.clock import TestClock
 from metis.scheduling.retry import FixedDelayRetryPolicy
-from metis.scheduling.scheduler import BackgroundCommand, InMemoryTaskScheduler, TaskStatus
+from metis.scheduling.scheduler import (
+    BackgroundCommand,
+    InMemoryTaskScheduler,
+    TaskStatus,
+)
 from metis.scheduling.worker import Worker
+
+
+def test_worker_defaults_to_null_event_publisher():
+    clock = TestClock(datetime(2026, 1, 1, 9, 0, tzinfo=timezone.utc))
+    scheduler = InMemoryTaskScheduler(clock=clock)
+
+    worker = Worker(scheduler=scheduler, clock=clock)
+
+    assert isinstance(worker.event_bus, NullEventPublisher)
 
 
 def test_worker_executes_due_task():
@@ -33,6 +47,7 @@ def test_worker_retries_failed_task():
     """
     A failing task should be rescheduled when retry budget remains.
     """
+
     class FailingTask(BackgroundCommand):
         def execute(self, context=None):
             raise RuntimeError("temporary failure")


### PR DESCRIPTION
**Summary**

- Add the EventPublisher protocol and stateless NullEventPublisher
- Normalize optional publishers in ModelManager and Worker
- Remove repeated publisher-presence checks from client workflows
- Preserve existing event_bus constructor compatibility
- Add a runnable real, null, and omitted publisher example
- Add contract, lifecycle, substitution, failure-propagation, and default-selection tests

**Validation**

- Full test suite: 254 tests passed
- Focused Chapter 15 regression suite: 29 tests passed
- Black formatting check passed
- Scoped strict type checking passed
- Real, null, and omitted examples return identical model responses, while only the real publisher dispatches events